### PR TITLE
Remove old Google based haskell-cafe.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,6 @@ script:
     stack exec haskellnews haskellnews.conf &
     sleep 1 && curl http://0.0.0.0:10010/ > /dev/null
     pkill haskell
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
     sed -i 's/pass = haskellnews/pass = postgres/g' haskellnews.conf >> haskellnews.conf
 
 script:
-  - stack build --no-terminal --install-ghc --test --haddock --no-haddock-deps --pedantic
+  - stack build --no-terminal --install-ghc --test --haddock --no-haddock-deps
   - stack exec haskellnews haskellnews.conf create-version
   - stack exec haskellnews haskellnews.conf migrate
   - stack exec haskellnews haskellnews.conf github

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # 0.1.1.1 (unreleased)
 
+* Remove haskell-cafe google feed (see [PR #55]).
+* Add mailman parser (see [PR #53]).
 * Add RSS feed to `/mixed` view (see [PR #48]).
 * Remove unused Git submodule (see [PR #47]).
 * Replace `MonadCatchIO` dependency with `exceptions` (see [PR #49]).
 
-[PR #49]: https://github.com/chrisdone/haskellnews/pull/48
+[PR #54]: https://github.com/chrisdone/haskellnews/pull/55
+[PR #53]: https://github.com/chrisdone/haskellnews/pull/53
+[PR #49]: https://github.com/chrisdone/haskellnews/pull/49
 [PR #48]: https://github.com/chrisdone/haskellnews/pull/48
 [PR #47]: https://github.com/chrisdone/haskellnews/pull/47
 

--- a/src/HN/Model/Feeds.hs
+++ b/src/HN/Model/Feeds.hs
@@ -21,22 +21,11 @@ import Text.Feed.Types
 --------------------------------------------------------------------------------
 -- Various service feeds
 
-importHaskellCafe :: Model c s (Either String ())
-importHaskellCafe = do
-  importGenerically HaskellCafe
-                    "https://groups.google.com/forum/feed/haskell-cafe/msgs/rss_v2_0.xml"
-                    (\item -> return (item { niTitle = strip (niTitle item) }))
-
-  where strip x | isPrefixOf "re: " (map toLower x) = strip (drop 4 x)
-                | isPrefixOf label x = drop (length label) x
-                | otherwise = x
-        label = "[Haskell-cafe]"
-
 importHaskellCafeNative :: Model c s (Either String ())
 importHaskellCafeNative =
   importMailman 50
                 HaskellCafeNative
-                "https://mail.haskell.org/pipermail/haskell-cafe/" 
+                "https://mail.haskell.org/pipermail/haskell-cafe/"
                 (\item -> return (item { niTitle = strip (niTitle item) }))
 
   where strip x | isPrefixOf "re: " (map toLower x) = strip (drop 4 x)

--- a/src/HN/Model/Import.hs
+++ b/src/HN/Model/Import.hs
@@ -22,7 +22,6 @@ importEverything = void $ do
         ,(importHaskellWiki,"importHaskellWiki")
         ,(importStackOverflow,"importStackOverflow")
         ,(importPlanetHaskell,"importPlanetHaskell")
-        -- ,(importHaskellCafeNative,"importHaskellCafe")
         ,(importHaskellCafeNative,"importHaskellCafeNative")
         ,(importGooglePlus,"importGooglePlus")
         ,(importIrcQuotes,"importIrcQuotes")

--- a/src/HN/Model/Mailman.hs
+++ b/src/HN/Model/Mailman.hs
@@ -4,32 +4,26 @@
 -- and https://github.com/haskell-infra/hl/issues/63#issuecomment-74420850
 
 {-# language OverloadedStrings #-}
-{-# language BangPatterns #-}
 
 module HN.Model.Mailman where
 
 import Network.HTTP.Conduit
--- I tried with
--- import HN.Curl
--- but could not get it to work reliably:
--- segfaults, badcertfile, and other erratic behaviour
--- on opening the second HTTPS connection.
 
 import Text.Feed.Types
 import Text.Feed.Constructor
 
 import qualified Text.HTML.DOM
 import Text.XML
-import Text.XML.Cursor
-import qualified Data.Text as T 
+import Text.XML.Cursor as XMLCursor
+import Text.XML.Cursor.Generic as XMLGeneric
+import qualified Data.Text as T
 
 import Data.Time.Format
 import Data.Time.LocalTime ( ZonedTime )
--- import Data.Time ( rfc822DateFormat, defaultTimeLocale )
 import Data.Char (isDigit)
 
-test1 = do
-  downloadFeed 10 "https://mail.haskell.org/pipermail/haskell-cafe/"
+test1 :: IO (Either String Feed)
+test1 = downloadFeed 10 "https://mail.haskell.org/pipermail/haskell-cafe/"
 
 
 -- | look at archive and produce a feed.
@@ -54,11 +48,11 @@ downloadFeed its uri= do
             [] -> "Tue Feb 17 18:55:05 UTC 2015"
             d : _ -> d
       let feed0 = newFeed (RSSKind Nothing)
-          feed = id
-               $ withFeedPubDate pubdate
-               $ foldr addItem feed0 items
+          feed = withFeedPubDate pubdate
+              $ foldr addItem feed0 items
       return $ Right feed
 
+getDoc :: String -> IO (Either a Document)
 getDoc uri = do
   result <- simpleHttp uri
   return $ Right $ Text.HTML.DOM.parseLBS result
@@ -74,7 +68,7 @@ getItems its uri dates =
     d:ates -> do
       result <- getDoc $ uri ++ T.unpack d
       let items = case result of
-            Left err -> []
+            Left _ -> []
             Right doc ->
               let cursor = fromDocument doc
               in  descendant cursor
@@ -82,31 +76,35 @@ getItems its uri dates =
                   >>= hasAttribute "HREF"
                   >>= parent
                   >>= element "LI"
-                  >>= mkItem uri (dropSuffix "thread.html" d ) 
+                  >>= mkItem uri (dropSuffix "thread.html" d )
       later <- getItems (its - length items) uri ates
       return $ items ++ later
 
+dropSuffix :: T.Text -> T.Text -> T.Text
 dropSuffix suf s =
   if T.isSuffixOf suf s
   then T.take (T.length s - T.length suf) s
   else s
 
+fetchDate :: XMLGeneric.Cursor Node -> T.Text -> [String]
 fetchDate cursor desc = do
   d <- fetch cursor desc
   -- we get this from mailman "Tue Feb 17 18:55:05 UTC 2015"
   -- and apparently we need "Tue, 17 Feb 2015 21:12:55 UTC"
-  t <- maybe [] return $ parseTime defaultTimeLocale "%a %b %d %H:%M:%S %Z %Y" $ T.unpack d
+  t <- maybe [] return $ parseTimeM True defaultTimeLocale "%a %b %d %H:%M:%S %Z %Y" $ T.unpack d
   return $ formatTime defaultTimeLocale rfc822DateFormat ( t :: ZonedTime )
 
+fetch :: XMLGeneric.Cursor Node -> T.Text -> [T.Text]
 fetch cursor desc = descendant cursor
                     >>= element "b"
                     >>= hasChildContents desc
                     >>= followingSibling
                     >>= element "i" >>= child >>= content
 
-hasChildContents desc =
-  check $ \ c -> desc == T.concat (child c >>= content )
-        
+hasChildContents :: T.Text -> XMLCursor.Axis
+hasChildContents desc = check $ \ c -> desc == T.concat (child c >>= content )
+
+mkItem :: String -> T.Text -> XMLGeneric.Cursor Node -> [Item]
 mkItem uri d c = do
   href <- child c >>= element "A" >>= laxAttribute "HREF"
   title <- child c >>= element "A" >>= hasAttribute "HREF"
@@ -118,9 +116,9 @@ mkItem uri d c = do
   -- and we need to get to this part: --------------------^^^^^^^^^^^
   -- which gives the epoch time of the current message
   NodeComment com <- map node ( precedingSibling c >>= precedingSibling )
-  let (s,t) = T.breakOnEnd "." com
+  let (s,_) = T.breakOnEnd "." com
       n = T.reverse $ T.takeWhile isDigit $ T.drop 1 $ T.reverse s
-      Just pubdate = parseTime defaultTimeLocale "%s" $ T.unpack n
+      Just pubdate = parseTimeM True defaultTimeLocale "%s" $ T.unpack n
       pubdateString = formatTime defaultTimeLocale rfc822DateFormat ( pubdate :: ZonedTime )
   let unpack = T.unpack . T.unwords . T.words
   return $ withItemLink (uri ++ T.unpack d ++ T.unpack href)

--- a/src/HN/Types.hs
+++ b/src/HN/Types.hs
@@ -91,7 +91,6 @@ data Source
   | StackOverflow
   | Jobs
   | PlanetHaskell
-  | HaskellCafe
   | HaskellCafeNative
   | GooglePlus
   | IrcQuotes
@@ -111,7 +110,6 @@ sourceMapping =
   ,(StackOverflow,7)
   ,(Jobs,8)
   ,(PlanetHaskell,9)
-  ,(HaskellCafe,10)
   ,(GooglePlus,11)
   ,(IrcQuotes,12)
   ,(Pastes,13)
@@ -139,7 +137,6 @@ sourceToString i =
       StackOverflow -> "Stack Overflow"
       Jobs -> "Jobs"
       PlanetHaskell -> "Planet Haskell"
-      HaskellCafe -> "Haskell-Cafe"
       HaskellCafeNative -> "Haskell-Cafe"
       GooglePlus -> "Google+"
       IrcQuotes -> "IRC Quotes"
@@ -159,7 +156,6 @@ sourceToUrl i =
       StackOverflow -> "http://stackoverflow.com/questions/tagged/haskell?sort=newest"
       Jobs -> "http://www.haskellers.com/jobs"
       PlanetHaskell -> "https://planet.haskell.org/"
-      HaskellCafe -> "https://groups.google.com/forum/#!forum/haskell-cafe"
       HaskellCafeNative -> "https://mail.haskell.org/pipermail/haskell-cafe/"
       GooglePlus -> "https://plus.google.com/communities/104818126031270146189?hl=en"
       IrcQuotes -> "http://ircbrowse.net/haskell"

--- a/src/HN/View/Home.hs
+++ b/src/HN/View/Home.hs
@@ -69,9 +69,7 @@ mixedRows now items =
   forM_ items $ \item ->
     tr ! id (toValue ("item-" ++ epoch (iPublished item))) $ do
       td !. "icon" $
-        img ! src (if iSource item == HaskellCafe
-                      then "http://www.haskell.org/favicon.ico"
-                      else toValue (show ((iLink item) { uriPath = "/favicon.ico" })))
+        img ! src (toValue (show ((iLink item) { uriPath = "/favicon.ico" })))
             !. "favicon"
             ! title (toValue (iSource item))
       td $ do


### PR DESCRIPTION
Follows on from the #53. Closes #51.

I'll wait for something on https://github.com/haskellnews/haskellnews/issues/54.