### PR TITLE
Remove Google+ and Vimeo from grouped display

### DIFF
--- a/src/HN/Controllers.hs
+++ b/src/HN/Controllers.hs
@@ -14,12 +14,27 @@ import           Snap.App
 import           Snap.App.Cache
 import           Snap.App.RSS
 
+allSources :: [Source]
+allSources =
+  [ Reddit
+  , HaskellCafeNative
+  , StackOverflow
+  , Github
+  , PlanetHaskell
+  , Twitter
+  , Events
+  , Hackage
+  , Pastes
+  , HaskellWiki
+  , IrcQuotes
+  ]
+
 -- | Grouped display.
 grouped :: Controller Config PState ()
 grouped = do
   embeddable <- getStringMaybe "embeddable"
   viewCached (Grouped (isJust embeddable)) $ do
-    groups <- forM [Reddit,HaskellCafeNative,StackOverflow,Github,PlanetHaskell,GooglePlus,Twitter,Events,Hackage,Vimeo,Pastes,HaskellWiki,IrcQuotes] $ \source -> do
+    groups <- forM allSources $ \source -> do
       items <- model $ getItemsBySource source 10
       return (source,items)
     now <- io getZonedTime


### PR DESCRIPTION
Also putting the list of sources to the toplevel. See #65